### PR TITLE
Remove jet installation in Dockerfile

### DIFF
--- a/NVIDIA/benchmarks/gpt3/implementations/pytorch/Dockerfile
+++ b/NVIDIA/benchmarks/gpt3/implementations/pytorch/Dockerfile
@@ -117,9 +117,6 @@ RUN if [ "${MEGATRON_REVISION}" != SKIP ]; then \
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# JET
-RUN pip install jet-api --upgrade --extra-index-url https://sc-hw-artf.nvidia.com/api/pypi/hw-joc-pypi/simple --extra-index-url https://sc-hw-artf.nvidia.com/api/pypi/compute-pypi/simple
-
 # Benchmark code
 WORKDIR /workspace/llm
 


### PR DESCRIPTION
Remove JET installation as it is not needed to run the gpt3 benchmark